### PR TITLE
Refactored package name to prevent naming collision

### DIFF
--- a/ch03/src/main/java/com/_sun/ch03/Ch03Application.java
+++ b/ch03/src/main/java/com/_sun/ch03/Ch03Application.java
@@ -1,4 +1,4 @@
-package com.sun.ch03;
+package com._sun.ch03;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/ch03/src/main/java/com/_sun/ch03/controller/EmployeeController.java
+++ b/ch03/src/main/java/com/_sun/ch03/controller/EmployeeController.java
@@ -1,6 +1,6 @@
-package com.sun.ch03.controller;
+package com._sun.ch03.controller;
 
-import com.sun.ch03.model.Emploee;
+import com._sun.ch03.model.Emploee;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/ch03/src/main/java/com/_sun/ch03/model/Emploee.java
+++ b/ch03/src/main/java/com/_sun/ch03/model/Emploee.java
@@ -1,4 +1,4 @@
-package com.sun.ch03.model;
+package com._sun.ch03.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/ch03/src/test/java/com/_sun/ch03/Ch03ApplicationTests.java
+++ b/ch03/src/test/java/com/_sun/ch03/Ch03ApplicationTests.java
@@ -1,4 +1,4 @@
-package com.sun.ch03;
+package com._sun.ch03;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
Refactored `com.sun.ch03` to `com._sun.ch03` (`sun` to `_sun`) to prevent naming collisions with Oracle's existing `com.sun` package.

[Click here](https://github.com/AussieDev81/thymeleaf-problem.git) to see `com.cun` package artifacts 